### PR TITLE
Fixed minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This repository contains the Unity3D client for the main [Neural MMO](https://github.com/jsuarez5341/neural-mmo) project. It's written in C# in a manner accessible to researchers and developers who work primarily in Python.
 
 
-**Setup**: Follow the instructions in the [Documentation](https://neuralmmo.github.io>).
+**Setup**: Follow the instructions in the [Documentation](https://neuralmmo.github.io).
 
 
 **Authorship and License**: I, Joseph Suarez, am the author of the Unity Client. It is available under the MIT license.


### PR DESCRIPTION
Changed `https://neuralmmo.github.io>` to `https://neuralmmo.github.io`